### PR TITLE
fix 多个滚动条 并且不在元素父级的情况

### DIFF
--- a/src/cacheReducer.js
+++ b/src/cacheReducer.js
@@ -4,7 +4,7 @@ function cacheReducer(cacheStates = {}, { type, payload }) {
         case cacheTypes.CREATE:
             return { ...cacheStates,
                 [payload.cacheId]: {
-                    scrolls:{},
+                    scrolls:new Map(),
                     cacheId:payload.cacheId,
                     element:payload.element,
                     status:cacheTypes.CREATE

--- a/src/withKeepAlive.js
+++ b/src/withKeepAlive.js
@@ -1,8 +1,22 @@
 import React, { useContext, useRef,useEffect } from "react";
 import CacheContext from './CacheContext';
 import * as cacheTypes from './cache-types';
+
+const setScrollTop=(dom,cacheState)=>{
+    const next=(dom)=>{
+        if(cacheState.scrolls.get(dom)){
+            dom.scrollTop = cacheState.scrolls.get(dom);
+        }
+        Array.from(dom.children).forEach(item=>{
+            next(item)
+        })
+    }
+    next(dom)
+}
 function withKeepAlive(OldComponent, { cacheId = window.location.pathname,scroll=false }) {
+    
     return function (props) {
+        console.log('Render');
         const {mount, cacheStates,dispatch,handleScroll } = useContext(CacheContext);
         const ref = useRef(null);
         useEffect(()=>{
@@ -16,15 +30,16 @@ function withKeepAlive(OldComponent, { cacheId = window.location.pathname,scroll
                 let doms = cacheState.doms;
                 doms.forEach(dom=>ref.current.appendChild(dom));
                 if(scroll){
+                    // 递归解决
                    doms.forEach(dom=>{
-                       if (cacheState.scrolls[dom])
-                         dom.scrollTop = cacheState.scrolls[dom];
+                        setScrollTop(dom,cacheState)      
                    });
                   }
             }else{
-                mount({ cacheId, element: <OldComponent {...props} dispatch={dispatch}/> })
+                mount({ cacheId, element:<OldComponent {...props} dispatch={dispatch}/>})
             }
         }, [cacheStates, dispatch, mount, props]);
+        // return <OldComponent></OldComponent>
         return <div id={`keepalive_${cacheId}`} ref={ref} />;
     }
 }


### PR DESCRIPTION
userList 是这种结构的话，里面有多个滚动条，记录不了。
`import { useState } from 'react';
import { useNavigate } from 'react-router';

function List(props) {
    let navigate =useNavigate()
    let [arr, setArr] = useState(Array(50).fill(0))
    let [isShow, setIsShow] = useState(true)
    return <>
        <button onClick={()=>{
            navigate({pathname:'/add'})
        }}>跳转</button>
        <button onClick={() => {
            props.dispatch({ type: 'DESTROY', payload: { cacheId: 'list' } })
            setIsShow(!isShow)
            setArr(Array(100).fill(0))
        }}>增加</button>
        {isShow ? <div>111111</div> : null}
        <ul style={{ height: '100px', overflow: 'auto' }}>
            {arr.map((item, index) => {
                return <li key={index}>{index}</li>
            })}
        </ul>
        <ul style={{ height: '100px', overflow: 'auto',marginTop:'20px' }}>
            {arr.map((item, index) => {
                return <li key={index}>{index}</li>
            })}
        </ul>
    </>
}

export default List`